### PR TITLE
Announce the same if using Windows 11 22h2 or not

### DIFF
--- a/addon/globalPlugins/SayStatedropbox.py
+++ b/addon/globalPlugins/SayStatedropbox.py
@@ -125,12 +125,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# announce dropbox state
 			if win11_22h2:
 				del(name[0:3])
-				name = " ".join(name)
-				ui.message(name)
-			else:
-				del(name[1])
-				name = " ".join(name)
-				ui.message(name)
+			del(name[1])
+			name = " ".join(name)
+			ui.message(name)
 
 		else:
 			# activate dropbox icon


### PR DESCRIPTION
Stop announcing the Dropbox version as it is the case for other windows versions, so only announce "Dropbox up to date" for example.